### PR TITLE
fix: install `rapidjson` when `*.deb` is cached

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,10 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           wget "https://launchpad.net/ubuntu/+source/rapidjson/1.1.0+dfsg2-3/+build/14513429/+files/rapidjson-dev_1.1.0+dfsg2-3_all.deb" -O rapidjson.deb
-          sudo dpkg -i rapidjson.deb
 
       - name: Install toolchain
         run: |
+          sudo dpkg -i rapidjson.deb
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
 


### PR DESCRIPTION
If the download was cached, the `deb` erroneously was not installed.